### PR TITLE
Interaction through egg + remove deprecation warning

### DIFF
--- a/Egg.js
+++ b/Egg.js
@@ -15,9 +15,7 @@ export default class Egg extends Component {
       num: -1,
       opacity: new Animated.Value(1),
     };
-  }
 
-  componentWillMount() {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
       onStartShouldSetPanResponderCapture: (evt, gestureState) => false,

--- a/Egg.js
+++ b/Egg.js
@@ -20,7 +20,7 @@ export default class Egg extends Component {
   componentWillMount() {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: (evt, gestureState) => true,
-      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => false,
       onPanResponderGrant: (evt, gestureState) => {
         if (this.props.touchOpacity) {
           Animated.timing(

--- a/Egg.js
+++ b/Egg.js
@@ -34,7 +34,7 @@ export default class Egg extends Component {
         this.gestureSetp(gestureState);
       },
       onShouldBlockNativeResponder: (evt, gestureState) => {
-        return true;
+        return false;
       },
     });
   }


### PR DESCRIPTION
Allow interaction through egg on iOS, e.g. allow to scroll a webview which is behind/inside the egg. 

Replace deprecated componentWillMount with constructor. 